### PR TITLE
qmemman: fix null reference bug

### DIFF
--- a/qmemman/qmemman_server.py
+++ b/qmemman/qmemman_server.py
@@ -74,6 +74,10 @@ class XS_Watcher:
         self.log.debug('domain_list_changed(param={!r})'.format(param))
 
         curr = self.handle.ls('', '/local/domain')
+
+        if curr == None:
+            return
+
         # check if domain is really there, it may happen that some empty
         # directories are left in xenstore
         curr = filter(
@@ -85,9 +89,6 @@ class XS_Watcher:
         )
 
         self.log.debug('curr={!r}'.format(curr))
-
-        if curr == None:
-            return
 
         self.log.debug('acquiring global_lock')
         global_lock.acquire()


### PR DESCRIPTION
Commit fef8761f017f0136280046a49d2322bcee2dba16 seems to have introduced a bug in qmemman.

curr can be None as the presence of the check and experience on my system shows, but then calling filter on curr which is None triggers an exception.

Instead, check for None before calling filter.

None values will no longer be logged to debug output with this fix: this is easy to solve if that's a desirable thing (not sure).
