### PR TITLE
backup: Allow to specify custom temporary directory

### DIFF
--- a/core/backup.py
+++ b/core/backup.py
@@ -449,7 +449,8 @@ def prepare_backup_header(target_directory, passphrase, compressed=False,
 def backup_do(base_backup_dir, files_to_backup, passphrase,
               progress_callback=None, encrypted=False, appvm=None,
               compressed=False, hmac_algorithm=DEFAULT_HMAC_ALGORITHM,
-              crypto_algorithm=DEFAULT_CRYPTO_ALGORITHM):
+              crypto_algorithm=DEFAULT_CRYPTO_ALGORITHM,
+              tmpdir="/var/tmp"):
     global running_backup_operation
 
     def queue_put_with_check(proc, vmproc, queue, element):
@@ -510,7 +511,7 @@ def backup_do(base_backup_dir, files_to_backup, passphrase,
         progress = blocks_backedup * 11 / total_backup_sz
         progress_callback(progress)
 
-    backup_tmpdir = tempfile.mkdtemp(prefix="/var/tmp/backup_")
+    backup_tmpdir = tempfile.mkdtemp(prefix="{}/backup_".format(tmpdir))
     running_backup_operation.tmpdir_to_remove = backup_tmpdir
 
     # Tar with tape length does not deals well with stdout (close stdout between

--- a/qvm-tools/qvm-backup
+++ b/qvm-tools/qvm-backup
@@ -67,6 +67,10 @@ def main():
                        dest="compress_filter", default=False,
                        help="Compress the backup using specified filter "
                             "program (default: gzip)")
+    parser.add_option("--tmpdir", action="store", dest="tmpdir", default=None,
+                      help="Custom temporary directory (if you have at least "
+                           "1GB free RAM in dom0, use of /tmp is advised) ("
+                           "default: /var/tmp)")
     parser.add_option ("--debug", action="store_true", dest="debug",
                        default=False, help="Enable (a lot of) debug output")
 
@@ -180,6 +184,8 @@ def main():
         kwargs['hmac_algorithm'] = options.hmac_algorithm
     if options.crypto_algorithm:
         kwargs['crypto_algorithm'] = options.crypto_algorithm
+    if options.tmpdir:
+        kwargs['tmpdir'] = options.tmpdir
 
     try:
         backup_do(base_backup_dir, files_to_backup, passphrase,


### PR DESCRIPTION
Using tmpfs-backed directory may speed up the backup process.

QubesOS/qubes-issues#1652
